### PR TITLE
fix: Hide internal MongoDB _id from API responses

### DIFF
--- a/apps/web/app/api/admin/log/route.ts
+++ b/apps/web/app/api/admin/log/route.ts
@@ -5,7 +5,7 @@ import jwt from "jsonwebtoken";
 import { cookies } from "next/headers";
 import { headers } from "next/headers";
 import { rateLimit } from "@/lib/rateLimiter";
-import { paginationSchema }  from "@repo/types/zod";
+import { paginationSchema } from "@repo/types/zod";
 
 const RATE_LIMIT = 20; // 20 requests
 const WINDOW_SEC = 5; // 5 seconds
@@ -81,6 +81,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
             .sort({ timestamp: -1 })
             .skip(skip)
             .limit(limit)
+            .select("-_id -__v")
             .lean();
 
 

--- a/apps/web/app/api/admin/recent-feedback/route.ts
+++ b/apps/web/app/api/admin/recent-feedback/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { CategoryFeedback } from "@/dbConnection/Schema/categoryFeedback";
 import { connectDb } from "@/dbConnection/connect";
 import jwt from 'jsonwebtoken';
@@ -6,7 +6,7 @@ import { cookies } from "next/headers";
 
 const JWT_SECRET = process.env.JWT_SECRET_KEY || 'your-secret';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
     try {
 
         const cookieStore = await cookies();
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
             .sort({ createdAt: -1 })
             .limit(10);
 
-        return NextResponse.json({ success: true, recentFeedback, request: request.url }, { status: 200 });
+        return NextResponse.json({ success: true, recentFeedback }, { status: 200 });
 
     } catch (error) {
         return NextResponse.json({

--- a/apps/web/app/api/admin/recent-protected/route.ts
+++ b/apps/web/app/api/admin/recent-protected/route.ts
@@ -34,6 +34,7 @@ export async function GET(): Promise<NextResponse> {
         const recentRequests = await MobileProtectionRequest.find()
             .sort({ createdAt: -1 })
             .limit(10)
+            .select("-_id -__v")
             .lean();
 
         return NextResponse.json({

--- a/apps/web/app/api/admin/stats/route.ts
+++ b/apps/web/app/api/admin/stats/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { connectDb } from "@/dbConnection/connect";
 import { Log } from "@/dbConnection/Schema/logs";
 import { Redis } from "ioredis";
@@ -17,7 +17,7 @@ function getRedis(): Redis {
     return redis;
 }
 
-export async function GET(request: NextRequest) {
+export async function GET() {
     try {
         const cookieStore = await cookies();
         const tokenCookie = cookieStore.get('ADMIN_AUTH_SMS_BOMBER');
@@ -63,7 +63,6 @@ export async function GET(request: NextRequest) {
             {
                 success: true,
                 message: "Stats fetched successfully",
-                request: request.url,
                 data: {
                     totalRequests,
                     last24hRequests,


### PR DESCRIPTION
This change improves data privacy and prevents unintended exposure of internal database identifiers

closes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admin Recent Feedback endpoint now requires authentication (cookie/JWT).
  - Standardized admin API responses: added success flag; removed extraneous request URL from responses.

- Bug Fixes
  - Admin Logs and Recent Protected endpoints no longer include internal database fields in results, improving data privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->